### PR TITLE
debian: add optional 3D printing tools install

### DIFF
--- a/debian/bootstrap
+++ b/debian/bootstrap
@@ -36,6 +36,13 @@ then
         source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-makemkv)
     fi
 
+    printf "Install 3D printing tools (PrusaSlicer, FreeCAD, OpenSCAD)? "
+    read -r REPLY </dev/tty
+    if [[ $REPLY =~ ^[Yy]$ ]]
+    then
+        source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-3d-printing-packages)
+    fi
+
     # Install Ghostty catppuccin theme
     source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-ghostty-catppuccin-theme)
 fi

--- a/debian/install-3d-printing-packages
+++ b/debian/install-3d-printing-packages
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-3d-printing-packages)
+
+# Install flatpak if not already present
+if ! command -v flatpak &>/dev/null; then
+    sudo apt-get install -y flatpak || { echo "ERROR: Failed to install flatpak"; return 1; }
+fi
+
+# Add Flathub remote if not already configured
+if ! flatpak remotes | grep -q flathub; then
+    sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || { echo "ERROR: Failed to add Flathub remote"; return 1; }
+fi
+
+# Install PrusaSlicer
+if ! flatpak list | grep -q com.prusa3d.PrusaSlicer; then
+    sudo flatpak install -y flathub com.prusa3d.PrusaSlicer || echo "WARNING: PrusaSlicer install failed"
+else
+    echo "PrusaSlicer is already installed, skipping."
+fi
+
+# Install FreeCAD
+if ! flatpak list | grep -q org.freecad.FreeCAD; then
+    sudo flatpak install -y flathub org.freecad.FreeCAD || echo "WARNING: FreeCAD install failed"
+else
+    echo "FreeCAD is already installed, skipping."
+fi
+
+# Install OpenSCAD
+if ! flatpak list | grep -q org.openscad.OpenSCAD; then
+    sudo flatpak install -y flathub org.openscad.OpenSCAD || echo "WARNING: OpenSCAD install failed"
+else
+    echo "OpenSCAD is already installed, skipping."
+fi

--- a/debian/install-3d-printing-packages
+++ b/debian/install-3d-printing-packages
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 # source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-3d-printing-packages)
 
-# Install flatpak if not already present
-if ! command -v flatpak &>/dev/null; then
-    sudo apt-get install -y flatpak || { echo "ERROR: Failed to install flatpak"; return 1; }
-fi
-
-# Add Flathub remote if not already configured
-if ! flatpak remotes | grep -q flathub; then
-    sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo || { echo "ERROR: Failed to add Flathub remote"; return 1; }
-fi
-
 # Install PrusaSlicer
 if ! flatpak list | grep -q com.prusa3d.PrusaSlicer; then
     sudo flatpak install -y flathub com.prusa3d.PrusaSlicer || echo "WARNING: PrusaSlicer install failed"

--- a/debian/install-desktop-packages
+++ b/debian/install-desktop-packages
@@ -26,6 +26,7 @@ code \
 darktable \
 evolution \
 evolution-ews \
+flatpak \
 fonts-cascadia-code \
 fonts-firacode \
 ghostty \
@@ -51,6 +52,14 @@ xclip
 # 32-bit apps fail with "could not load kernel32.dll, status c0000135".
 if [ ! -d "$HOME/.wine" ]; then
     WINEARCH=win64 WINEDEBUG=-all wineboot --init
+fi
+
+# Set up Flathub remote and install Flatseal (Flatpak permissions manager)
+sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+if ! flatpak list | grep -q com.github.tchx84.Flatseal; then
+    sudo flatpak install -y flathub com.github.tchx84.Flatseal || echo "WARNING: Flatseal install failed"
+else
+    echo "Flatseal is already installed, skipping."
 fi
 
 # Pango 1.56.x workaround: when FONTCONFIG_FILE is unset (or set to the default


### PR DESCRIPTION
## Summary

Adds a new `install-3d-printing-packages` script and optional bootstrap prompt for 3D printing tools. Moves Flatpak setup into the main desktop packages script.

## Tools Included

- **PrusaSlicer** (`com.prusa3d.PrusaSlicer`) — slicer for FDM/SLA printers
- **FreeCAD** (`org.freecad.FreeCAD`) — parametric 3D CAD modeler
- **OpenSCAD** (`org.openscad.OpenSCAD`) — programmable solid 3D modeler

## Approach

All three are installed via **Flatpak from Flathub**, providing the latest upstream versions independent of Debian's package freeze and keeping apps updatable via `flatpak update`.

## Changes

- `debian/install-desktop-packages` — adds `flatpak` package, Flathub remote setup, and **Flatseal** (Flatpak permissions manager)
- `debian/install-3d-printing-packages` — new script; installs the three apps via Flatpak (skipping any already installed)
- `debian/bootstrap` — adds optional prompt for 3D printing tools, following the same pattern as makemkv