### PR TITLE
Add blender and gnome-software flatpak plugin

### DIFF
--- a/debian/install-desktop-packages
+++ b/debian/install-desktop-packages
@@ -22,6 +22,7 @@ sudo apt-get update
 # Install graphical desktop packages
 sudo apt-get install -y \
 audacity \
+blender \
 code \
 darktable \
 evolution \
@@ -32,6 +33,7 @@ fonts-firacode \
 ghostty \
 gimp \
 gnome-browser-connector \
+gnome-software-plugin-flatpak \
 gnome-tweaks \
 handbrake \
 kdiff3 \


### PR DESCRIPTION
Add the blender 3D graphics creation suite to the graphical desktop packages list. Also install gnome-software-plugin-flatpak to enable managing Flatpak applications directly inside GNOME Software.