### PR TITLE
Add dev tools support (.NET SDK 10, mise, just, pandoc) to Debian bootstrap

### DIFF
--- a/debian/bootstrap
+++ b/debian/bootstrap
@@ -19,6 +19,14 @@ source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/m
 # Install packages
 source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-packages)
 
+# Dev packages
+printf "Install development tools? "
+read -r REPLY </dev/tty
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-dev-packages)
+fi
+
 # Install eza themes
 source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-eza-themes)
 

--- a/debian/install-dev-packages
+++ b/debian/install-dev-packages
@@ -50,6 +50,7 @@ libtool \
 make \
 mercurial \
 mise \
+pandoc \
 pylint \
 python-is-python3 \
 python3-autopep8 \

--- a/debian/install-dev-packages
+++ b/debian/install-dev-packages
@@ -17,6 +17,15 @@ else
     echo "WARNING: Failed to download Microsoft repository package from $MS_URL"
 fi
 
+# Register mise package repository
+echo "Registering mise package repository..."
+sudo install -dm 755 /etc/apt/keyrings
+if curl -fSs https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg > /dev/null; then
+    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list > /dev/null
+else
+    echo "WARNING: Failed to register mise package repository"
+fi
+
 sudo apt-get update
 
 # Install dev packages
@@ -29,16 +38,18 @@ checkinstall \
 cmake \
 default-jdk \
 dialog \
-dotnet-sdk-8.0 \
+dotnet-sdk-10.0 \
 flex \
 golang \
 hugo \
 jq \
+just \
 libcurl4-openssl-dev \
 libssl-dev \
 libtool \
 make \
 mercurial \
+mise \
 pylint \
 python-is-python3 \
 python3-autopep8 \
@@ -46,3 +57,13 @@ python3-pip \
 twine \
 universal-ctags \
 zlib1g-dev
+
+# Activate mise for bash and zsh configurations
+echo "Adding mise activation hooks to shell configurations..."
+if [ -f "$HOME/.bashrc" ] && ! grep -q "mise activate bash" "$HOME/.bashrc"; then
+    printf '\n# Activate mise version manager\neval "$(mise activate bash)"\n' >> "$HOME/.bashrc"
+fi
+
+if [ -f "$HOME/.zshrc" ] && ! grep -q "mise activate zsh" "$HOME/.zshrc"; then
+    printf '\n# Activate mise version manager\neval "$(mise activate zsh)"\n' >> "$HOME/.zshrc"
+fi

--- a/debian/install-dev-packages
+++ b/debian/install-dev-packages
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-dev-packages)
+
+# Get Debian version to fetch correct Microsoft repo package
+source /etc/os-release
+VERSION_ID=${VERSION_ID:-12} # Default to 12 if unset
+
+# Register Microsoft package repository for .NET SDK
+MS_DEB="packages-microsoft-prod.deb"
+MS_URL="https://packages.microsoft.com/config/debian/${VERSION_ID}/packages-microsoft-prod.deb"
+
+echo "Registering Microsoft package repository..."
+if wget -q "$MS_URL" -O "$MS_DEB"; then
+    sudo dpkg -i "$MS_DEB"
+    rm -f "$MS_DEB"
+else
+    echo "WARNING: Failed to download Microsoft repository package from $MS_URL"
+fi
+
+sudo apt-get update
+
+# Install dev packages
+sudo apt-get install -y \
+autoconf \
+autogen \
+bison \
+build-essential \
+checkinstall \
+cmake \
+default-jdk \
+dialog \
+dotnet-sdk-8.0 \
+flex \
+golang \
+hugo \
+jq \
+libcurl4-openssl-dev \
+libssl-dev \
+libtool \
+make \
+mercurial \
+pylint \
+python-is-python3 \
+python3-autopep8 \
+python3-pip \
+twine \
+universal-ctags \
+zlib1g-dev

--- a/test/docker/run-tests-debian.sh
+++ b/test/docker/run-tests-debian.sh
@@ -7,6 +7,9 @@ cd /home/testuser/linux-bootstrap
 echo "Testing Debian package installation..."
 bash debian/install-packages
 
+echo "Testing Debian dev package installation..."
+bash debian/install-dev-packages
+
 echo ""
 echo "Verifying packages are installed..."
 PACKAGES=(
@@ -43,6 +46,14 @@ PACKAGES=(
     zoxide
     zsh
     zsh-doc
+    build-essential
+    cmake
+    default-jdk
+    dotnet-sdk-10.0
+    golang
+    just
+    mise
+    pandoc
 )
 
 MISSING=()


### PR DESCRIPTION
This PR introduces development tools installation support to the Debian bootstrap configuration, aligning it with the existing Ubuntu bootstrap pattern.

### Features Added:
- **New debian/install-dev-packages Script:**
  - Installs essential development utilities (`build-essential`, `cmake`, `make`, etc.).
  - Configures the official Microsoft package repository and installs the **.NET SDK 10.0**.
  - Configures the official **mise** package repository, installs the CLI, and appends the necessary activation hooks to user shell files (`~/.bashrc` and `~/.zshrc`).
  - Installs the **just** command runner and **pandoc** document converter.
  - Installs general compilers and runtime engines (`golang`, `default-jdk`).
- **Interactive Prompts in debian/bootstrap:**
  - Prompts the user before executing the development package installation, keeping it modular and optional.
- **Automated Docker Testing:**
  - Updated `test/docker/run-tests-debian.sh` to run the new script and verify that all target packages are successfully installed and active in clean container environments.