### PR TITLE
chore: Apply idempotent _gext_install pattern to all distros

### DIFF
--- a/debian/install-desktop-packages
+++ b/debian/install-desktop-packages
@@ -126,17 +126,25 @@ fc-cache -f
 # Install Gnome extension tooling and selected extensions
 pipx install gnome-extensions-cli --system-site-packages
 
+# We use both tools here for efficient idempotency:
+# - `gnome-extensions list` is native, local, and its output is more easily parseable (cleanly outputs raw UUIDs for grep).
+# - `gext` connects to extensions.gnome.org to download the correct zip file automatically.
 _gext_install() {
     local uuid="$1"
-    if ! gnome-extensions list | grep -q "$uuid"; then
+    if command -v gnome-extensions >/dev/null 2>&1; then
+        if ! gnome-extensions list | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext install "$uuid"
+        else
+            echo "GNOME extension $uuid is already installed, skipping."
+        fi
+        if ! gnome-extensions list --enabled | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext enable "$uuid"
+        else
+            echo "GNOME extension $uuid is already enabled, skipping."
+        fi
+    else
         "$HOME"/.local/bin/gext install "$uuid"
-    else
-        echo "GNOME extension $uuid is already installed, skipping."
-    fi
-    if ! gnome-extensions list --enabled | grep -q "$uuid"; then
         "$HOME"/.local/bin/gext enable "$uuid"
-    else
-        echo "GNOME extension $uuid is already enabled, skipping."
     fi
 }
 
@@ -144,6 +152,7 @@ _gext_install caffeine@patapon.info
 _gext_install dash-to-dock@micxgx.gmail.com
 _gext_install freon@UshakovVasilii_Github.yahoo.com
 _gext_install clipboard-history@alexsaveau.dev
+_gext_install appindicatorsupport@rgcjonas.gmail.com
 unset -f _gext_install
 
 # Move window buttons to the left

--- a/fedora/install-packages
+++ b/fedora/install-packages
@@ -116,11 +116,31 @@ sudo update-alternatives --install /usr/bin/vim vim $(which nvim) 10
 pipx install gnome-extensions-cli --system-site-packages
 
 # Install Gnome Extensions
-"$HOME"/.local/bin/gext install paperwm@paperwm.github.com
-"$HOME"/.local/bin/gext install clipboard-history@alexsaveau.dev
+# We use both tools here for efficient idempotency:
+# - `gnome-extensions list` is native, local, and its output is more easily parseable (cleanly outputs raw UUIDs for grep).
+# - `gext` connects to extensions.gnome.org to download the correct zip file automatically.
+_gext_install() {
+    local uuid="$1"
+    if command -v gnome-extensions >/dev/null 2>&1; then
+        if ! gnome-extensions list | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext install "$uuid"
+        else
+            echo "GNOME extension $uuid is already installed, skipping."
+        fi
+        if ! gnome-extensions list --enabled | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext enable "$uuid"
+        else
+            echo "GNOME extension $uuid is already enabled, skipping."
+        fi
+    else
+        "$HOME"/.local/bin/gext install "$uuid"
+        "$HOME"/.local/bin/gext enable "$uuid"
+    fi
+}
 
-"$HOME"/.local/bin/gext enable paperwm@paperwm.github.com
-"$HOME"/.local/bin/gext enable clipboard-history@alexsaveau.dev
+_gext_install paperwm@paperwm.github.com
+_gext_install clipboard-history@alexsaveau.dev
+unset -f _gext_install
 
 # Move window buttons to the left
 gsettings get org.gnome.desktop.wm.preferences button-layout

--- a/pop_os/install-packages
+++ b/pop_os/install-packages
@@ -112,17 +112,34 @@ zsh-doc
 
 # Install Gnome extensions
 pipx install gnome-extensions-cli --system-site-packages
-"$HOME"/.local/bin/gext install caffeine@patapon.info
-"$HOME"/.local/bin/gext install blur-my-shell@aunetx
-"$HOME"/.local/bin/gext install clipboard-history@alexsaveau.dev
-"$HOME"/.local/bin/gext install freon@UshakovVasilii_Github.yahoo.com
-"$HOME"/.local/bin/gext install paperwm@paperwm.github.com
+# We use both tools here for efficient idempotency:
+# - `gnome-extensions list` is native, local, and its output is more easily parseable (cleanly outputs raw UUIDs for grep).
+# - `gext` connects to extensions.gnome.org to download the correct zip file automatically.
+_gext_install() {
+    local uuid="$1"
+    if command -v gnome-extensions >/dev/null 2>&1; then
+        if ! gnome-extensions list | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext install "$uuid"
+        else
+            echo "GNOME extension $uuid is already installed, skipping."
+        fi
+        if ! gnome-extensions list --enabled | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext enable "$uuid"
+        else
+            echo "GNOME extension $uuid is already enabled, skipping."
+        fi
+    else
+        "$HOME"/.local/bin/gext install "$uuid"
+        "$HOME"/.local/bin/gext enable "$uuid"
+    fi
+}
 
-"$HOME"/.local/bin/gext enable caffeine@patapon.info
-"$HOME"/.local/bin/gext enable blur-my-shell@aunetx
-"$HOME"/.local/bin/gext enable clipboard-history@alexsaveau.dev
-"$HOME"/.local/bin/gext enable freon@UshakovVasilii_Github.yahoo.com
-"$HOME"/.local/bin/gext enable paperwm@paperwm.github.com
+_gext_install caffeine@patapon.info
+_gext_install blur-my-shell@aunetx
+_gext_install clipboard-history@alexsaveau.dev
+_gext_install freon@UshakovVasilii_Github.yahoo.com
+_gext_install paperwm@paperwm.github.com
+unset -f _gext_install
 
 # Move window buttons to the left
 gsettings get org.gnome.desktop.wm.preferences button-layout

--- a/ubuntu/install-desktop-packages
+++ b/ubuntu/install-desktop-packages
@@ -50,14 +50,32 @@ youtube-music \
 
 pipx install gnome-extensions-cli --system-site-packages
 
+# We use both tools here for efficient idempotency:
+# - `gnome-extensions list` is native, local, and its output is more easily parseable (cleanly outputs raw UUIDs for grep).
+# - `gext` connects to extensions.gnome.org to download the correct zip file automatically.
+_gext_install() {
+    local uuid="$1"
+    if command -v gnome-extensions >/dev/null 2>&1; then
+        if ! gnome-extensions list | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext install "$uuid"
+        else
+            echo "GNOME extension $uuid is already installed, skipping."
+        fi
+        if ! gnome-extensions list --enabled | grep -q "$uuid"; then
+            "$HOME"/.local/bin/gext enable "$uuid"
+        else
+            echo "GNOME extension $uuid is already enabled, skipping."
+        fi
+    else
+        "$HOME"/.local/bin/gext install "$uuid"
+        "$HOME"/.local/bin/gext enable "$uuid"
+    fi
+}
 
-"$HOME"/.local/bin/gext install caffeine@patapon.info
-"$HOME"/.local/bin/gext install clipboard-history@alexsaveau.dev
-"$HOME"/.local/bin/gext install freon@UshakovVasilii_Github.yahoo.com
-
-"$HOME"/.local/bin/gext enable caffeine@patapon.info
-"$HOME"/.local/bin/gext enable clipboard-history@alexsaveau.dev
-"$HOME"/.local/bin/gext enable freon@UshakovVasilii_Github.yahoo.com
+_gext_install caffeine@patapon.info
+_gext_install clipboard-history@alexsaveau.dev
+_gext_install freon@UshakovVasilii_Github.yahoo.com
+unset -f _gext_install
 
 # Move window buttons to the left
 gsettings get org.gnome.desktop.wm.preferences button-layout


### PR DESCRIPTION
This PR standardizes the idempotent installation pattern for GNOME extensions across Fedora, Pop!_OS, and Ubuntu, matching the Debian script. It also adds a comment clarifying why both native `gnome-extensions list` (for parseability and local idempotency) and `gext` (for downloading) are used together.