### PR TITLE
Add Claude Code and rtk installers to Debian bootstrap

### DIFF
--- a/debian/bootstrap
+++ b/debian/bootstrap
@@ -25,6 +25,8 @@ read -r REPLY </dev/tty
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/debian/install-dev-packages)
+    source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-claude-code)
+    source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-rtk)
 fi
 
 # Install eza themes

--- a/generic/install-claude-code
+++ b/generic/install-claude-code
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-claude-code)
+
+if command -v claude >/dev/null 2>&1; then
+    echo "Claude Code is already installed, skipping."
+else
+    curl -fsSL https://claude.ai/install.sh | bash
+fi

--- a/generic/install-rtk
+++ b/generic/install-rtk
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/generic/install-rtk)
+
+if command -v rtk >/dev/null 2>&1; then
+    echo "rtk is already installed, skipping."
+else
+    curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+fi


### PR DESCRIPTION
## Summary
- Add `generic/install-claude-code` and `generic/install-rtk`, each installing via the tool's official curl install script and skipping if already present
- Wire both into `debian/bootstrap` under the existing "Install development tools?" prompt, alongside `debian/install-dev-packages`
- Placed in `generic/` (not `debian/`) since neither install depends on apt/distro-specific packaging, so other distro bootstraps can reuse them later

## Test plan
- [x] `bash -n` on all three changed/added scripts
- [x] Ran both new scripts locally and confirmed the "already installed, skipping" idempotency path
- [ ] Optional: run full Debian bootstrap on a clean VM to confirm end-to-end install