### PR TITLE
Set debconf frontend to Readline before apt upgrades

### DIFF
--- a/debian/install-packages
+++ b/debian/install-packages
@@ -19,6 +19,10 @@ sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/charm.gpg
 echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
 
+# Use the Readline debconf frontend so package prompts (e.g. service restarts
+# during upgrades) render as plain text instead of an unreadable whiptail dialog
+echo "debconf debconf/frontend select Readline" | sudo debconf-set-selections
+
 # Update package repos
 sudo apt-get update
 

--- a/pop_os/install-packages
+++ b/pop_os/install-packages
@@ -9,6 +9,10 @@ sudo add-apt-repository -y universe
 # Add Neovim PPA
 sudo add-apt-repository ppa:neovim-ppa/unstable -y
 
+# Use the Readline debconf frontend so package prompts (e.g. service restarts
+# during upgrades) render as plain text instead of an unreadable whiptail dialog
+echo "debconf debconf/frontend select Readline" | sudo debconf-set-selections
+
 # Update package repos
 sudo apt-get update
 

--- a/ubuntu/install-essential-packages
+++ b/ubuntu/install-essential-packages
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # source <(curl -fsSL https://raw.githubusercontent.com/mapitman/linux-bootstrap/main/ubuntu/install-essential-packages)
 
+# Use the Readline debconf frontend so package prompts (e.g. service restarts
+# during upgrades) render as plain text instead of an unreadable whiptail dialog
+echo "debconf debconf/frontend select Readline" | sudo debconf-set-selections
+
 # Update package repos
 sudo apt-get update
 


### PR DESCRIPTION
## Summary
- The whiptail/dialog debconf frontend used by `apt upgrade` can render prompts (e.g. "Which services should be restarted?") with a low-contrast color scheme that's unreadable in some terminals.
- Sets the debconf frontend to Readline before `apt-get upgrade` in `debian/install-packages`, `ubuntu/install-essential-packages`, and `pop_os/install-packages`, so these prompts fall back to plain text and always render correctly.

## Test plan
- [ ] Run `just test` (or the relevant `test-debian`/`test-all` recipe) to confirm the affected scripts still complete successfully
- [ ] Manually trigger an apt upgrade with a pending debconf prompt (e.g. via `needrestart`/service-restart prompts) and confirm it now appears as plain text instead of the dialog